### PR TITLE
[FIXED JENKINS-8128] Tagging a build is not working

### DIFF
--- a/src/main/java/hudson/scm/CVSSCM.java
+++ b/src/main/java/hudson/scm/CVSSCM.java
@@ -1684,11 +1684,6 @@ public class CVSSCM extends SCM implements Serializable {
                     continue;
                 }
                 listener.getLogger().println(Messages.CVSSCM_TagginXasY(e.getKey(),e.getValue()));
-                try {
-                    e.getKey().keepLog();
-                } catch (IOException x) {
-                    x.printStackTrace(listener.error(Messages.CVSSCM_FailedToMarkForKeep(e.getKey())));
-                }
                 ta.perform(e.getValue(), listener);
                 listener.getLogger().println();
             }


### PR DESCRIPTION
I removed the call to "keepLog()" from the body of the "perform(...)"-method since "keepLog" uses a method that checks for the "UPDATE"-permission which the "Anonymous"-user might not hold ...in which case tagging fails. The "anonymous"-user comes into play regardless of the actual user submitting the task because the "perform"-method of the TagWorkerThread is run from a separate thread that has no user associated with it and thus revert to the "anonymous" user.

"keepLog()" doesn't seem to play any vital part in the tagging - I guess it was supposed to store the output of the tagging process for later querying, however, I've never seen any tagging logs resulting from a successful tagging. After I applied this fix tagging also succeeds even though the anonymous user does not have the update permission.
