### PR TITLE
fix [JENKINS-12586] cvs-plugin fails to read old changelog files

### DIFF
--- a/src/main/java/hudson/scm/CVSChangeLogSet.java
+++ b/src/main/java/hudson/scm/CVSChangeLogSet.java
@@ -149,9 +149,9 @@ public final class CVSChangeLogSet extends ChangeLogSet<CVSChangeLog> {
         private static final DateFormat CHANGE_DATE_FORMATTER = new SimpleDateFormat(
                         "yyyy-MM-dd HH:mm:ss");
         private static final DateFormat DATE_FORMATTER = new SimpleDateFormat(
-                        "yyyy/MM/dd");
+                        "yyyy-MM-dd");
         private static final DateFormat TIME_FORMATTER = new SimpleDateFormat(
-                        "HH:mm:ss");
+                        "HH:mm");
 
         private User author;
         private String msg;

--- a/src/test/java/hudson/scm/CVSChangeLogParserTest.java
+++ b/src/test/java/hudson/scm/CVSChangeLogParserTest.java
@@ -1,0 +1,22 @@
+package hudson.scm;
+
+import java.io.File;
+import java.net.URISyntaxException;
+
+import org.junit.Test;
+import org.jvnet.hudson.test.HudsonTestCase;
+
+public class CVSChangeLogParserTest extends HudsonTestCase {
+
+    // borrowed from core/test/.../TestResultTest
+    private File getDataFile(String name) throws URISyntaxException {
+        return new File(CVSChangeLogParserTest.class.getResource(name).toURI());
+    }
+
+    // verify fix for JENKINS-12586
+    @Test
+    public void testParseOldFile() throws Exception {
+        CVSChangeLogSet result = new CVSChangeLogParser().parse(null, getDataFile("changelogOldFormat.xml"));
+        assertNotNull(result);
+    }
+}

--- a/src/test/resources/hudson/scm/changelogOldFormat.xml
+++ b/src/test/resources/hudson/scm/changelogOldFormat.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+example changelog.xml from 1.6 plugin, the format has changed in 2.0
+but the old format is still read.
+The file is used to check parsing the old format to verify this issue: 
+https://issues.jenkins-ci.org/browse/JENKINS-12586
+the old format uses yyyy-mm-DD and HH:mm for date and time
+ -->
+ <changelog>
+        <entry>
+                <date>2011-12-14</date>
+                <time>23:26</time>
+                <author><![CDATA[user]]></author>
+                <file>
+                        <name><![CDATA[file]]></name>
+                        <fullName><![CDATA[/cvs/file1]]></fullName>
+                        <revision>1.1.2.1</revision>
+                </file>
+                <msg><![CDATA[example entry]]></msg>
+        </entry>
+</changelog>


### PR DESCRIPTION
test and fix for the issue, old files contain date with yyyy-mm-DD and HH:mm, but the parser uses yyyy/mm/DD and HH:mm:ss
