### PR TITLE
fix [JENKINS-13439] Tagging a build fails due to exception

### DIFF
--- a/src/main/java/hudson/scm/cvstagging/CvsTagActionWorker.java
+++ b/src/main/java/hudson/scm/cvstagging/CvsTagActionWorker.java
@@ -24,9 +24,10 @@ public class CvsTagActionWorker extends TaskThread {
     private final AbstractBuild<?, ?> build;
     private final CvsTagAction parent;
 
+    @SuppressWarnings("deprecation") // use a deprecated method, so we can support as many versions of Jenkins as possible
     public CvsTagActionWorker(final CvsRevisionState revisionState,
                     final String tagName, final AbstractBuild<?, ?> build, final CvsTagAction parent) {
-        super(parent, ListenerAndText.forMemory(null));
+        super(parent, ListenerAndText.forMemory());
         this.revisionState = revisionState;
         this.tagName = tagName;
         this.build = build;


### PR DESCRIPTION
the bug was caused by an api incompability, 
the method ListenerAndText.forMemory(Lhudson/model/TaskThread;) is no longer available in jenkins-core since at least jenkins 1.422.
cvs-plugin will now require Core 1.422
