### PR TITLE
additional fix for JENKINS-13439 Tagging a build fails due to exception

### DIFF
--- a/src/main/java/hudson/scm/cvstagging/LegacyTagAction.java
+++ b/src/main/java/hudson/scm/cvstagging/LegacyTagAction.java
@@ -365,9 +365,10 @@ public class LegacyTagAction extends AbstractScmTagAction implements
     public static final class LegacyTagWorkerThread extends TaskThread {
         private final Map<AbstractBuild<?, ?>, String> tagSet;
 
+        @SuppressWarnings("deprecation") // use a deprecated method, so we can support as many versions of Jenkins as possible
         public LegacyTagWorkerThread(final LegacyTagAction owner,
                         final Map<AbstractBuild<?, ?>, String> tagSet) {
-            super(owner, ListenerAndText.forMemory(null));
+            super(owner, ListenerAndText.forMemory());
             this.tagSet = tagSet;
         }
 


### PR DESCRIPTION
do the same as commit 1a8d25a32daf1ec84f601c0ebefc42b6ade77524 with the
remaining ListenerAndText.forMemory(Lhudson/model/TaskThread;) method
call
