### PR TITLE
[FIXED JENKINS-14848] switch to using User.getByCommitName() for revision information

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.400</version>
+    <version>1.477</version>
     <relativePath />
   </parent>
 

--- a/src/main/java/hudson/scm/CVSChangeLogSet.java
+++ b/src/main/java/hudson/scm/CVSChangeLogSet.java
@@ -337,7 +337,7 @@ public final class CVSChangeLogSet extends ChangeLogSet<CVSChangeLog> {
         }
 
         public void setUser(final String author) {
-            this.author = User.get(author);
+            this.author = User.getByCommitName(author);
         }
 
         @Exported


### PR DESCRIPTION
This updates the User.get() function call on a revision for an author to User.getByCommitName() to prevent possible duplicate Jenkins user creation.  If you have user "john" committing from location one as "j.doe" and location two as "john.doe", it is now possible to prevent automatic new Jenkins user creation by mapping both of those commit names.

This change requires [this pull request](https://github.com/jenkinsci/jenkins/pull/534)'s integration into Jenkins core.
