### PR TITLE
FIXED JENKINS-17470 uncheck "Show all CVS Output" has no effect

### DIFF
--- a/src/main/java/hudson/scm/AbstractCvs.java
+++ b/src/main/java/hudson/scm/AbstractCvs.java
@@ -350,6 +350,7 @@ public abstract class AbstractCvs extends SCM implements ICvs {
     public GlobalOptions getGlobalOptions(CvsRepository repository, EnvVars envVars) {
         final GlobalOptions globalOptions = new GlobalOptions();
         globalOptions.setVeryQuiet(!isDisableCvsQuiet());
+        globalOptions.setModeratelyQuiet(!isDisableCvsQuiet());
         globalOptions.setCompressionLevel(getCompressionLevel(repository, envVars));
         globalOptions.setCVSRoot(envVars.expand(repository.getCvsRoot()));
         return globalOptions;


### PR DESCRIPTION
I've used wireshark to compare protocol frame for command line cvs -Q update vs jenkins plugin with veryQuiet set. command line do set both Global Options -q and -Q. Seems cvs server ignore -Q if -q is not set, not sure this is documented by CVS spec, but this is the actual behavior.
