### PR TITLE
[ZD-19670] CloudBees customer reported that the quite period checkout be...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.447</version>
+    <version>1.520</version>
   </parent>
 
   <artifactId>cvs</artifactId>

--- a/src/main/java/jenkins/scm/cvs/QuietPeriodCompleted.java
+++ b/src/main/java/jenkins/scm/cvs/QuietPeriodCompleted.java
@@ -1,0 +1,65 @@
+package jenkins.scm.cvs;
+
+import hudson.Extension;
+import hudson.model.Action;
+import hudson.model.Cause;
+import hudson.model.Queue;
+import hudson.model.queue.QueueListener;
+import hudson.triggers.SCMTrigger;
+
+import java.util.Date;
+
+/**
+* @author Stephen Connolly
+*/
+public class QuietPeriodCompleted implements Action {
+
+    private final long timestamp;
+
+    public QuietPeriodCompleted() {
+        timestamp = System.currentTimeMillis();
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public Date getTimestampDate() {
+        return new Date(timestamp);
+    }
+
+    @Override
+    public String getIconFileName() {
+        return null;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return null;
+    }
+
+    @Override
+    public String getUrlName() {
+        return null;
+    }
+
+    @Extension
+    public static class SCMTriggerTimeObserver extends QueueListener {
+
+        @Override
+        public void onLeaveWaiting(Queue.WaitingItem wi) {
+            SCMTrigger.SCMTriggerCause scmCause = null;
+            for (Cause c: wi.getCauses()) {
+                if (c instanceof SCMTrigger.SCMTriggerCause) {
+                    scmCause = (SCMTrigger.SCMTriggerCause) c;
+                    break;
+                }
+            }
+            if (scmCause != null && wi.getAction(QuietPeriodCompleted.class) == null) {
+                wi.addAction(new QuietPeriodCompleted());
+            }
+        }
+    }
+
+
+}

--- a/src/main/resources/hudson/scm/CVSSCM/config.jelly
+++ b/src/main/resources/hudson/scm/CVSSCM/config.jelly
@@ -48,4 +48,7 @@ THE SOFTWARE.
     <f:entry title="${%Force clean copy for locally modified files}" field="forceCleanCopy">
          <f:checkbox />
     </f:entry>
+    <f:entry title="${%Use start of checkout operation as timestamp}" field="checkoutCurrentTimestamp">
+         <f:checkbox default="false"/>
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/scm/CVSSCM/help-checkoutCurrentTimestamp.html
+++ b/src/main/resources/hudson/scm/CVSSCM/help-checkoutCurrentTimestamp.html
@@ -1,0 +1,8 @@
+<div>
+    The build quiet period is designed to assist with CVS checkouts by waiting for a specific period of time without
+    commits. Normally you want the checkout to reflect the time when the quiet period was exited successfully.
+    Select this option if you need to re-enable the legacy behaviour of Jenkins, i.e. using the time that the build
+    started checking out as the timestamp for the checkout operation. Note: enabling this option can
+    result in the quiet period being defeated especially in those cases where the build is not able to start immediately
+    after exiting the quiet period.
+</div>


### PR DESCRIPTION
...haviour has anomolous logic that can result in failed builds
- This is likely where there is a delay between the build leaving the quiet period and the build starting
- If there is a commit during that period of time then the build may checkout an inconsistent state
- The solution is to use the time when the quiet period is completed as the timestamp for the checkout
- Obviously people may prefer the original behaviour in some cases
