### PR TITLE
Allow '-' characters in repository path

### DIFF
--- a/src/main/java/hudson/scm/CvsProjectset.java
+++ b/src/main/java/hudson/scm/CvsProjectset.java
@@ -46,7 +46,7 @@ import java.util.regex.Pattern;
 public class CvsProjectset extends AbstractCvs {
 
     private static final Pattern PSF_PATTERN = Pattern.compile("<project reference=\"[^,]+,((:[a-z]+:)([a-z|A-Z|0-9|\\.\\-]+)" +
-            "(:([0-9]+)?)?([/|a-z|A-Z|_|0-9]+)),([/|A-Z|a-z|0-9|_|\\.|\\-]+),([A-Z|a-z|0-9|_|\\.|\\-]+)(,(.*?)){0,1}\"/>");
+            "(:([0-9]+)?)?([/|a-z|A-Z|_|0-9|\\-]+)),([/|A-Z|a-z|0-9|_|\\.|\\-]+),([A-Z|a-z|0-9|_|\\.|\\-]+)(,(.*?)){0,1}\"/>");
 
     private final CvsRepository[] repositories;
     private final boolean canUseUpdate;


### PR DESCRIPTION
The regex pattern does not match for entries containing '-' characters in the repository path.

Example:

```
<project reference="1.0,:extssh:myHostname:/var/lib/cvs-roots/myRepo,path/to/project,project"/>
```

Because '/var/lib/cvs-roots/myRepo' contains a '-' character it will not match. With the provided patch it will match.
