### PR TITLE
allow '/' characters in local path

### DIFF
--- a/src/main/java/hudson/scm/CvsProjectset.java
+++ b/src/main/java/hudson/scm/CvsProjectset.java
@@ -46,7 +46,7 @@ import java.util.regex.Pattern;
 public class CvsProjectset extends AbstractCvs {
 
     private static final Pattern PSF_PATTERN = Pattern.compile("<project reference=\"[^,]+,((:[a-z]+:)([a-z|A-Z|0-9|\\.\\-]+)" +
-            "(:([0-9]+)?)?([/|a-z|A-Z|_|0-9|\\-]+)),([/|A-Z|a-z|0-9|_|\\.|\\-]+),([A-Z|a-z|0-9|_|\\.|\\-]+)(,(.*?)){0,1}\"/>");
+            "(:([0-9]+)?)?([/|a-z|A-Z|_|0-9|\\-]+)),([/|A-Z|a-z|0-9|_|\\.|\\-]+),([A-Z|a-z|0-9|_|\\.|\\-|/]+)(,(.*?)){0,1}\"/>");
 
     private final CvsRepository[] repositories;
     private final boolean canUseUpdate;


### PR DESCRIPTION
The regex pattern does not match for entries containing '/' characters in the local path. This makes it impossible to check out projects to a specific local directory.

Example:

```
<project reference="1.0,:extssh:myHostname:/path/to/repo,MyProject,localDirectory/MyProject"/>
```

This should check out the project "MyProject" to "localDirectory/MyProject". Because of the '/' character the regular expression will not match. The patch fixes this.
