### PR TITLE
Update to work with the workflow plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.520</version>
+    <version>1.607</version>
   </parent>
 
   <artifactId>cvs</artifactId>

--- a/src/main/java/hudson/scm/AbstractCvs.java
+++ b/src/main/java/hudson/scm/AbstractCvs.java
@@ -82,6 +82,10 @@ import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 public abstract class AbstractCvs extends SCM implements ICvs {
 
     protected static final DateFormat DATE_FORMATTER = new SimpleDateFormat("dd MMM yyyy HH:mm:ss Z", Locale.UK);
@@ -476,6 +480,12 @@ public abstract class AbstractCvs extends SCM implements ICvs {
         return build.getAction(CvsRevisionState.class);
     }
 
+    @Override
+    public @CheckForNull SCMRevisionState calcRevisionsFromBuild(@Nonnull Run<?,?> build, @Nullable FilePath workspace,
+    		                                                     @Nullable Launcher launcher, @Nonnull TaskListener listener)
+    		                                                    		 throws IOException, InterruptedException {
+        return build.getAction(CvsRevisionState.class);
+    }
 
     protected PollingResult compareRemoteRevisionWith(final AbstractProject<?, ?> project, final Launcher launcher,
                                                       final FilePath workspace, final TaskListener listener,

--- a/src/main/java/hudson/scm/AbstractCvs.java
+++ b/src/main/java/hudson/scm/AbstractCvs.java
@@ -35,9 +35,10 @@ import hudson.model.TaskListener;
 import hudson.remoting.VirtualChannel;
 import hudson.scm.cvstagging.CvsTagAction;
 import hudson.util.Secret;
-
 import jenkins.scm.cvs.QuietPeriodCompleted;
+
 import org.apache.commons.io.output.DeferredFileOutputStream;
+import org.jenkinsci.remoting.RoleChecker;
 import org.netbeans.lib.cvsclient.CVSRoot;
 import org.netbeans.lib.cvsclient.Client;
 import org.netbeans.lib.cvsclient.admin.AdminHandler;
@@ -300,6 +301,12 @@ public abstract class AbstractCvs extends SCM implements ICvs {
                     }
                 }
             }
+
+			@Override
+			public void checkRoles(RoleChecker checker)
+					throws SecurityException {
+				// Do nothing
+			}
         })) {
             listener.error("Cvs task failed");
             return false;
@@ -677,6 +684,12 @@ public abstract class AbstractCvs extends SCM implements ICvs {
                 public CvsChangeSet invoke(File file, VirtualChannel virtualChannel) throws IOException, InterruptedException {
                     return executeRlog(cvsClient, rlogCommand, listener, encoding, globalOptions, repository, envVars, item.getLocation());
                 }
+
+    			@Override
+    			public void checkRoles(RoleChecker checker)
+    					throws SecurityException {
+    				// Do nothing
+    			}
             });
         }
 
@@ -838,6 +851,12 @@ public abstract class AbstractCvs extends SCM implements ICvs {
                             return null;
                         }
 
+            			@Override
+            			public void checkRoles(RoleChecker checker)
+            					throws SecurityException {
+            				// Do nothing
+            			}
+
                         private void cleanup(File directory, AdminHandler adminHandler) throws IOException {
                             for (File file : adminHandler.getAllFiles(directory)) {
                                 Entry entry = adminHandler.getEntry(file);
@@ -959,6 +978,12 @@ public abstract class AbstractCvs extends SCM implements ICvs {
                  */
                 return buildFileList(moduleLocation, envVars.expand(module.getRemoteName()));
             }
+
+			@Override
+			public void checkRoles(RoleChecker checker)
+					throws SecurityException {
+				// Do nothing
+			}
 
             public List<CvsFile> buildFileList(final File moduleLocation, final String prefix) throws IOException {
                 AdminHandler adminHandler = new StandardAdminHandler();

--- a/src/main/java/hudson/scm/AbstractCvs.java
+++ b/src/main/java/hudson/scm/AbstractCvs.java
@@ -30,6 +30,7 @@ import hudson.Launcher;
 import hudson.Util;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
+import hudson.model.Run;
 import hudson.model.BuildListener;
 import hudson.model.TaskListener;
 import hudson.remoting.VirtualChannel;
@@ -95,8 +96,8 @@ public abstract class AbstractCvs extends SCM implements ICvs {
     }
 
     protected boolean checkout(CvsRepository[] repositories, boolean isFlatten, FilePath workspace, boolean canUseUpdate,
-                               AbstractBuild<?, ?> build, String dateStamp, boolean pruneEmptyDirectories,
-                               boolean cleanOnFailedUpdate, BuildListener listener) throws IOException, InterruptedException {
+                               Run<?, ?> build, String dateStamp, boolean pruneEmptyDirectories,
+                               boolean cleanOnFailedUpdate, TaskListener listener) throws IOException, InterruptedException {
 
         final EnvVars envVars = build.getEnvironment(listener);
 
@@ -810,11 +811,11 @@ public abstract class AbstractCvs extends SCM implements ICvs {
         return changes;
     }
 
-    protected void postCheckout(AbstractBuild<?, ?> build, File changelogFile, CvsRepository[] repositories,
-                                FilePath workspace, final BuildListener listener, boolean flatten, EnvVars envVars)
+    protected void postCheckout(Run<?, ?> build, File changelogFile, CvsRepository[] repositories,
+                                FilePath workspace, final TaskListener listener, boolean flatten, EnvVars envVars)
             throws IOException, InterruptedException {
         // build change log
-        final AbstractBuild<?, ?> lastCompleteBuild = build.getPreviousBuiltBuild();
+        final Run<?, ?> lastCompleteBuild = build.getPreviousBuiltBuild();
 
         if (lastCompleteBuild != null && !isSkipChangeLog()) {
             final Date lastCompleteTimestamp = getCheckoutDate(lastCompleteBuild);
@@ -825,7 +826,7 @@ public abstract class AbstractCvs extends SCM implements ICvs {
                 changes.addAll(calculateChangeLog(lastCompleteTimestamp, checkoutDate, location,
                         listener, build.getEnvironment(listener), workspace));
             }
-            new CVSChangeLogSet(build,changes).toFile(changelogFile);
+            new CVSChangeLogSet(build, getBrowser(), changes).toFile(changelogFile);
         } else {
             createEmptyChangeLog(changelogFile, listener, "changelog");
         }
@@ -895,7 +896,7 @@ public abstract class AbstractCvs extends SCM implements ICvs {
         }
     }
 
-    protected Date getCheckoutDate(AbstractBuild<?, ?> build) {
+    protected Date getCheckoutDate(Run<?, ?> build) {
         QuietPeriodCompleted quietPeriodCompleted;
         Date checkoutDate;
         quietPeriodCompleted = build.getAction(QuietPeriodCompleted.class);

--- a/src/main/java/hudson/scm/CVSChangeLogParser.java
+++ b/src/main/java/hudson/scm/CVSChangeLogParser.java
@@ -24,6 +24,8 @@
 package hudson.scm;
 
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
+import hudson.scm.ChangeLogSet.Entry;
 
 import java.io.File;
 import java.io.IOException;
@@ -41,5 +43,10 @@ public class CVSChangeLogParser extends ChangeLogParser {
                     @SuppressWarnings("rawtypes") final AbstractBuild build,
                     final File changelogFile) throws IOException, SAXException {
         return CVSChangeLogSet.parse(build, changelogFile);
+    }
+    
+    @Override
+    public ChangeLogSet<? extends Entry> parse(Run build, RepositoryBrowser<?> browser, File changelogFile) throws IOException, SAXException {
+        return CVSChangeLogSet.parse(build, browser, changelogFile);
     }
 }

--- a/src/main/java/hudson/scm/CVSChangeLogSet.java
+++ b/src/main/java/hudson/scm/CVSChangeLogSet.java
@@ -105,7 +105,21 @@ public final class CVSChangeLogSet extends ChangeLogSet<CVSChangeLog> {
 
     public static CVSChangeLogSet parse(final AbstractBuild<?, ?> build,
             final java.io.File f) throws IOException, SAXException {
-        Digester digester = new Digester2();
+        ArrayList<CVSChangeLog> r = parseFile(f);
+
+        return new CVSChangeLogSet(build, r);
+    }
+
+    public static CVSChangeLogSet parse(final Run<?, ?> build, RepositoryBrowser<?> browser,
+            final java.io.File f) throws IOException, SAXException {
+        ArrayList<CVSChangeLog> r = parseFile(f);
+
+        return new CVSChangeLogSet(build, browser, r);
+    }
+
+	private static ArrayList<CVSChangeLog> parseFile(final java.io.File f)
+			throws IOException2 {
+		Digester digester = new Digester2();
         ArrayList<CVSChangeLog> r = new ArrayList<CVSChangeLog>();
         digester.push(r);
 
@@ -154,9 +168,9 @@ public final class CVSChangeLogSet extends ChangeLogSet<CVSChangeLog> {
                 r.remove(log);
             }
         }
-
-        return new CVSChangeLogSet(build, r);
-    }
+        
+		return r;
+	}
 
     /**
      * In-memory representation of CVS Changelog.

--- a/src/main/java/hudson/scm/CVSChangeLogSet.java
+++ b/src/main/java/hudson/scm/CVSChangeLogSet.java
@@ -24,6 +24,7 @@
 package hudson.scm;
 
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.model.User;
 import hudson.scm.CVSChangeLogSet.CVSChangeLog;
 import hudson.util.Digester2;
@@ -46,6 +47,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import jenkins.model.Jenkins;
+
 import org.apache.commons.digester.Digester;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
@@ -64,6 +66,15 @@ public final class CVSChangeLogSet extends ChangeLogSet<CVSChangeLog> {
     public CVSChangeLogSet(final AbstractBuild<?, ?> build,
             final List<CVSChangeLog> logs) {
         super(build);
+        this.logs = Collections.unmodifiableList(logs);
+        for (CVSChangeLog log : logs) {
+            log.setParent(this);
+        }
+    }
+
+    public CVSChangeLogSet(final Run<?, ?> build, RepositoryBrowser<?> browser,
+            final List<CVSChangeLog> logs) {
+        super(build, browser);
         this.logs = Collections.unmodifiableList(logs);
         for (CVSChangeLog log : logs) {
             log.setParent(this);

--- a/src/main/java/hudson/scm/CVSSCM.java
+++ b/src/main/java/hudson/scm/CVSSCM.java
@@ -592,7 +592,7 @@ public class CVSSCM extends AbstractCvs implements Serializable {
 
         private String tagName;
 
-        public TagAction(final AbstractBuild<?, ?> build) {
+        public TagAction(final Run<?, ?> build) {
             super(build);
         }
 

--- a/src/main/java/hudson/scm/cvstagging/CvsTagAction.java
+++ b/src/main/java/hudson/scm/cvstagging/CvsTagAction.java
@@ -56,7 +56,7 @@ public class CvsTagAction extends AbstractScmTagAction implements Describable<Cv
     private transient CVSSCM parent;
 
 
-    public CvsTagAction(final AbstractBuild<?, ?> build, final AbstractCvs parent) {
+    public CvsTagAction(final Run<?, ?> build, final AbstractCvs parent) {
         super(build);
         this.parentScm = parent;
     }

--- a/src/main/java/hudson/scm/cvstagging/LegacyTagAction.java
+++ b/src/main/java/hudson/scm/cvstagging/LegacyTagAction.java
@@ -67,7 +67,7 @@ public class LegacyTagAction extends AbstractScmTagAction implements
     private volatile String tagName;
     private CVSSCM parent;
 
-    public LegacyTagAction(final AbstractBuild<?, ?> build,
+    public LegacyTagAction(final Run<?, ?> build,
                     final CVSSCM parent) {
         super(build);
         this.parent = parent;


### PR DESCRIPTION
These changes were made to get the CVS plugin updated to the latest SCM code so that it will work with the workflow plugin.  For this I implemented three new methods and made minimal changes to others to get them into compliance.

I opened issue 27717 (https://issues.jenkins-ci.org/browse/JENKINS-27717) for this.