### PR TITLE
add MIT license

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,14 @@
         <name>Michael Clarke</name>
     </developer>
   </developers>
+  
+  <licenses>
+    <license>
+      <name>The MIT license</name>
+      <url>http://www.opensource.org/licenses/mit-license.php</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
 
   <scm>
     <connection>scm:git:https://github.com/jenkinsci/cvs-plugin.git</connection>


### PR DESCRIPTION
Hi there,

Thanks for your work on this plugin. We really appreciate your efforts at Swrve, but we've been unable to track down which license your plugin false under. I would have preferred to simply open an issue about this, but your repo doesn't seem to accept issues :cry:, hence this pull request. I've added the MIT license in this PR, as it seems to be used quite frequently by Jenkins plugins, although you can of course choose whichever license you like.