### PR TITLE
Fix JENKINS-33016: Jenkins doesn't detect CVS polling on Pipeline Job

### DIFF
--- a/src/main/java/hudson/scm/AbstractCvs.java
+++ b/src/main/java/hudson/scm/AbstractCvs.java
@@ -24,19 +24,30 @@
 package hudson.scm;
 
 
-import hudson.EnvVars;
-import hudson.FilePath;
-import hudson.Launcher;
-import hudson.Util;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
-import hudson.model.Run;
-import hudson.model.BuildListener;
-import hudson.model.TaskListener;
-import hudson.remoting.VirtualChannel;
-import hudson.scm.cvstagging.CvsTagAction;
-import hudson.util.Secret;
-import jenkins.scm.cvs.QuietPeriodCompleted;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
+import java.io.Reader;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import org.apache.commons.io.output.DeferredFileOutputStream;
 import org.jenkinsci.remoting.RoleChecker;
@@ -59,32 +70,18 @@ import org.netbeans.lib.cvsclient.connection.ConnectionFactory;
 import org.netbeans.lib.cvsclient.connection.ConnectionIdentity;
 import org.netbeans.lib.cvsclient.event.CVSListener;
 
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.PrintStream;
-import java.io.Reader;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.ListIterator;
-import java.util.Locale;
-import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
-
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.Util;
+import hudson.model.AbstractBuild;
+import hudson.model.Job;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.remoting.VirtualChannel;
+import hudson.scm.cvstagging.CvsTagAction;
+import hudson.util.Secret;
+import jenkins.scm.cvs.QuietPeriodCompleted;
 
 public abstract class AbstractCvs extends SCM implements ICvs {
 
@@ -487,12 +484,12 @@ public abstract class AbstractCvs extends SCM implements ICvs {
         return build.getAction(CvsRevisionState.class);
     }
 
-    protected PollingResult compareRemoteRevisionWith(final AbstractProject<?, ?> project, final Launcher launcher,
+    protected PollingResult compareRemoteRevisionWith(final Job<?, ?> project, final Launcher launcher,
                                                       final FilePath workspace, final TaskListener listener,
                                                       final SCMRevisionState baseline, final CvsRepository[] repositories)
             throws IOException, InterruptedException {
 
-        AbstractBuild<?, ?> build = project.getLastBuild();
+        Run<?, ?> build = project.getLastBuild();
 
         // No previous build? everything has changed
         if (null == build) {
@@ -500,13 +497,14 @@ public abstract class AbstractCvs extends SCM implements ICvs {
             return PollingResult.BUILD_NOW;
         }
 
-        if (!build.hasChangeSetComputed() && build.isBuilding()) {
-            listener.getLogger().println("Previous build has not finished checkout."
-                    + " Not triggering build as no valid baseline comparison available.");
-            return PollingResult.NO_CHANGES;
-        }
+        // Disable this check while the JENKINS-24141 is not resolved
+//        if (!build.hasChangeSetComputed() && build.isBuilding()) {
+//            listener.getLogger().println("Previous build has not finished checkout."
+//                    + " Not triggering build as no valid baseline comparison available.");
+//            return PollingResult.NO_CHANGES;
+//        }
 
-        final EnvVars envVars = project.getLastBuild().getEnvironment(listener);
+        final EnvVars envVars = build.getEnvironment(listener);
 
         final Date currentPollDate = Calendar.getInstance().getTime();
 

--- a/src/main/java/hudson/scm/CVSSCM.java
+++ b/src/main/java/hudson/scm/CVSSCM.java
@@ -23,23 +23,7 @@
  */
 package hudson.scm;
 
-import hudson.AbortException;
-import hudson.Extension;
-import hudson.FilePath;
-import hudson.Launcher;
-import hudson.model.*;
-import hudson.scm.browsers.CvsFacadeRepositoryBrowser;
-import hudson.scm.cvstagging.LegacyTagAction;
-import hudson.util.FormValidation;
-import hudson.util.Secret;
-import jenkins.scm.cvs.QuietPeriodCompleted;
-import net.sf.json.JSONObject;
-
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.export.Exported;
-import org.netbeans.lib.cvsclient.CVSRoot;
+import static hudson.Util.fixEmptyAndTrim;
 
 import java.io.File;
 import java.io.IOException;
@@ -57,7 +41,31 @@ import java.util.TreeSet;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
-import static hudson.Util.fixEmptyAndTrim;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.export.Exported;
+import org.netbeans.lib.cvsclient.CVSRoot;
+
+import hudson.AbortException;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.BuildListener;
+import hudson.model.Describable;
+import hudson.model.Descriptor;
+import hudson.model.Hudson;
+import hudson.model.Job;
+import hudson.model.ModelObject;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.scm.browsers.CvsFacadeRepositoryBrowser;
+import hudson.scm.cvstagging.LegacyTagAction;
+import hudson.util.FormValidation;
+import hudson.util.Secret;
+import net.sf.json.JSONObject;
 
 /**
  * CVS.
@@ -237,10 +245,10 @@ public class CVSSCM extends AbstractCvs implements Serializable {
      * Checks for differences between the current workspace and the remote
      * repository.
      *
-     * @see {@link SCM#compareRemoteRevisionWith(AbstractProject, Launcher, FilePath, TaskListener, SCMRevisionState)}
+     * @see {@link SCM#compareRemoteRevisionWith(Job, Launcher, FilePath, TaskListener, SCMRevisionState)}
      */
     @Override
-    protected PollingResult compareRemoteRevisionWith(final AbstractProject<?, ?> project, final Launcher launcher,
+    public PollingResult compareRemoteRevisionWith(final Job<?, ?> project, final Launcher launcher,
                                                       final FilePath workspace, final TaskListener listener, final SCMRevisionState baseline)
             throws IOException, InterruptedException {
 
@@ -356,19 +364,6 @@ public class CVSSCM extends AbstractCvs implements Serializable {
         }
 
         return locationName;
-    }
-
-    @Override
-    public boolean checkout(final AbstractBuild<?, ?> build, final Launcher launcher, final FilePath workspace,
-                            final BuildListener listener, final File changelogFile) throws IOException, InterruptedException {
-    	try {
-    		checkout(build, launcher, workspace, listener, changelogFile, null);
-    	}
-    	catch (AbortException e) {
-    		return false;
-    	}
-    	
-        return true;
     }
 
     @Override

--- a/src/main/java/hudson/scm/CvsProjectset.java
+++ b/src/main/java/hudson/scm/CvsProjectset.java
@@ -23,29 +23,39 @@
  */
 package hudson.scm;
 
-import hudson.AbortException;
-import hudson.Extension;
-import hudson.FilePath;
-import hudson.Launcher;
-import hudson.Util;
-import hudson.model.*;
-import hudson.scm.cvs.Messages;
-import hudson.util.Secret;
-
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.export.Exported;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.Exported;
+
+import hudson.AbortException;
+import hudson.AbortException;
+import hudson.Extension;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.Launcher;
+import hudson.Util;
+import hudson.Util;
+import hudson.model.Hudson;
+import hudson.model.Job;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.scm.cvs.Messages;
+import hudson.util.Secret;
+import hudson.util.Secret;
 
 
 public class CvsProjectset extends AbstractCvs {
@@ -103,27 +113,13 @@ public class CvsProjectset extends AbstractCvs {
     }
 
     @Override
-    protected PollingResult compareRemoteRevisionWith(AbstractProject<?, ?> project, Launcher launcher,
+    public PollingResult compareRemoteRevisionWith(Job<?, ?> project, Launcher launcher,
                                                       FilePath workspace, TaskListener listener,
                                                       SCMRevisionState baseline)
             throws IOException, InterruptedException {
         return super.compareRemoteRevisionWith(project, launcher, workspace,
                 listener, baseline, getAllRepositories(workspace));
     }
-
-    @Override
-    public boolean checkout(AbstractBuild<?, ?> build, Launcher launcher, FilePath workspace, BuildListener listener,
-                            File changelogFile) throws IOException, InterruptedException {
-    	try {
-    		checkout(build, launcher, workspace, listener, changelogFile, null);
-    	}
-    	catch (AbortException e) {
-    		return false;
-    	}
-    	
-        return true;
-    }
-
 
     @Override
     public void checkout(final @Nonnull Run<?,?> build, final @Nonnull Launcher launcher, final @Nonnull FilePath workspace,


### PR DESCRIPTION
These changes were made to enable the polling functionality in the Pipeline Jobs, as described in JENKINS-33016.