### PR TITLE
[FIXED JENKINS-26345] "CVS Symbolic Name parameter" not working any more

### DIFF
--- a/src/main/java/hudson/scm/CvsTagsParamDefinition.java
+++ b/src/main/java/hudson/scm/CvsTagsParamDefinition.java
@@ -218,14 +218,7 @@ public class CvsTagsParamDefinition extends ParameterDefinition {
 
     public Client getCvsClient(final String cvsRootString, final boolean passwordRequired, final Secret password) {
         CVSRoot cvsRoot = CVSRoot.parse(cvsRootString);
-        EnvVars envVars = new EnvVars();
-        try {
-            envVars = Computer.currentComputer().getEnvironment();
-        } catch (IOException e) {
-            //ignored, can't do much
-        } catch (InterruptedException e) {
-            //ignored, can't do much
-        }
+        EnvVars envVars = new EnvVars(System.getenv());
 
         CVSSCM.DescriptorImpl cvsDescriptor = getCvsDescriptor();
 


### PR DESCRIPTION
This fix is inspired by this commit: https://github.com/kohsuke/Hudson-GIT-plugin/commit/f92bb2fd650545e740f409824a6ca27fca34c70a

Please let me know if it can be improved.
