### PR TITLE
No need to bundle jsch.jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,11 @@
   
   <dependencies>
       <dependency>
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>jsch</artifactId>
+          <version>0.1.54.2</version>
+      </dependency>
+      <dependency>
           <groupId>org.jenkins-ci.lib</groupId>
           <artifactId>cvsclient</artifactId>
           <version>71-jenkins-11</version>


### PR DESCRIPTION
Minor follow-up to #46. https://github.com/jenkinsci/cvsclient/pull/3 (which I am _not_ proposing to integrate) passes with the dependency bump.

@reviewbybees