### PR TITLE
fixed missing "Excluded Region" field in CVS extended config settings

### DIFF
--- a/src/main/resources/hudson/scm/CvsRepository/config.jelly
+++ b/src/main/resources/hudson/scm/CvsRepository/config.jelly
@@ -56,7 +56,7 @@ THE SOFTWARE.
         </j:forEach>
       </f:dropdownList>
       <f:entry title="${%Exclude Regions}">
-        <f:repeatableProperty field="excludedRegions" noAddButton="true"/>
+        <f:repeatableProperty field="excludedRegions" noAddButton="true" minimum="1"/>
       </f:entry>
       <f:entry title="${%Compression Level}" field="compressionLevel">
         <f:select/>


### PR DESCRIPTION
This is an additional fix to PR #48 .
It re-enables the "Excluded Regions" textbox in CVS config so the handled nullpointer in PR #48 does not even occur. 

![excl_regions](https://user-images.githubusercontent.com/16672548/56062296-2f202e00-5d6c-11e9-9ac0-b508c9c3fd32.PNG)