### PR TITLE
[JENKINS-33016] Jenkins doesn't detect CVS polling on Pipeline (Workflow) Job

### DIFF
--- a/src/main/java/hudson/scm/CVSSCM.java
+++ b/src/main/java/hudson/scm/CVSSCM.java
@@ -251,6 +251,20 @@ public class CVSSCM extends AbstractCvs implements Serializable {
     }
 
     /**
+     * Checks for differences between the current workspace and the remote
+     * repository.
+     *
+     * @see SCM#compareRemoteRevisionWith(Job, Launcher, FilePath, TaskListener, SCMRevisionState)
+     */
+    @Override
+    public PollingResult compareRemoteRevisionWith(final Job<?, ?> project, final Launcher launcher,
+                                                      final FilePath workspace, final TaskListener listener, final SCMRevisionState baseline)
+            throws IOException, InterruptedException {
+
+        return super.compareRemoteRevisionWith(project, launcher, workspace, listener, baseline, getRepositories());
+    }
+
+    /**
      * If there are multiple modules, return the module directory of the first
      * one.
      *
@@ -359,19 +373,6 @@ public class CVSSCM extends AbstractCvs implements Serializable {
         }
 
         return locationName;
-    }
-
-    @Override
-    public boolean checkout(final AbstractBuild<?, ?> build, final Launcher launcher, final FilePath workspace,
-                            final BuildListener listener, final File changelogFile) throws IOException, InterruptedException {
-    	try {
-    		checkout(build, launcher, workspace, listener, changelogFile, null);
-    	}
-    	catch (AbortException e) {
-    		return false;
-    	}
-    	
-        return true;
     }
 
     @Override

--- a/src/main/java/hudson/scm/CVSSCM.java
+++ b/src/main/java/hudson/scm/CVSSCM.java
@@ -376,6 +376,19 @@ public class CVSSCM extends AbstractCvs implements Serializable {
     }
 
     @Override
+    public boolean checkout(final AbstractBuild<?, ?> build, final Launcher launcher, final FilePath workspace,
+                            final BuildListener listener, final File changelogFile) throws IOException, InterruptedException {
+    	try {
+    		checkout(build, launcher, workspace, listener, changelogFile, null);
+    	}
+    	catch (AbortException e) {
+    		return false;
+    	}
+    	
+        return true;
+    }
+
+    @Override
     public void checkout(final @Nonnull Run<?,?> build, final @Nonnull Launcher launcher, final @Nonnull FilePath workspace,
     		             final @Nonnull TaskListener listener, final @CheckForNull File changelogFile,
     		             final @CheckForNull SCMRevisionState baseline) throws IOException, InterruptedException {

--- a/src/main/java/hudson/scm/CvsProjectset.java
+++ b/src/main/java/hudson/scm/CvsProjectset.java
@@ -113,6 +113,15 @@ public class CvsProjectset extends AbstractCvs {
     }
 
     @Override
+    public PollingResult compareRemoteRevisionWith(Job<?, ?> project, Launcher launcher,
+                                                      FilePath workspace, TaskListener listener,
+                                                      SCMRevisionState baseline)
+            throws IOException, InterruptedException {
+        return super.compareRemoteRevisionWith(project, launcher, workspace,
+                listener, baseline, getAllRepositories(workspace));
+    }
+
+    @Override
     public boolean checkout(AbstractBuild<?, ?> build, Launcher launcher, FilePath workspace, BuildListener listener,
                             File changelogFile) throws IOException, InterruptedException {
     	try {


### PR DESCRIPTION
This is an adaption and minor improvement of #41 - it provides additional functions to enable SCM Polling in Pipelines but also keeps the currently used methods.