### PR TITLE
Replace JSR-305 annotations with spotbugs annotations

### DIFF
--- a/src/main/java/hudson/scm/AbstractCvs.java
+++ b/src/main/java/hudson/scm/AbstractCvs.java
@@ -82,9 +82,9 @@ import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 public abstract class AbstractCvs extends SCM implements ICvs {
 
@@ -476,8 +476,8 @@ public abstract class AbstractCvs extends SCM implements ICvs {
     }
 
     @Override
-    public @CheckForNull SCMRevisionState calcRevisionsFromBuild(@Nonnull Run<?,?> build, @Nullable FilePath workspace,
-    		                                                     @Nullable Launcher launcher, @Nonnull TaskListener listener)
+    public @CheckForNull SCMRevisionState calcRevisionsFromBuild(@NonNull Run<?,?> build, @Nullable FilePath workspace,
+                                                                 @Nullable Launcher launcher, @NonNull TaskListener listener)
     		                                                    		 throws IOException, InterruptedException {
         return build.getAction(CvsRevisionState.class);
     }

--- a/src/main/java/hudson/scm/CVSSCM.java
+++ b/src/main/java/hudson/scm/CVSSCM.java
@@ -57,11 +57,11 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 import static hudson.Util.fixEmptyAndTrim;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
@@ -377,8 +377,8 @@ public class CVSSCM extends AbstractCvs implements Serializable {
     }
 
     @Override
-    public void checkout(final @Nonnull Run<?,?> build, final @Nonnull Launcher launcher, final @Nonnull FilePath workspace,
-    		             final @Nonnull TaskListener listener, final @CheckForNull File changelogFile,
+    public void checkout(final @NonNull Run<?,?> build, final @NonNull Launcher launcher, final @NonNull FilePath workspace,
+                         final @NonNull TaskListener listener, final @CheckForNull File changelogFile,
     		             final @CheckForNull SCMRevisionState baseline) throws IOException, InterruptedException {
         if (!canUseUpdate) {
             workspace.deleteContents();
@@ -596,7 +596,7 @@ public class CVSSCM extends AbstractCvs implements Serializable {
         }
 
         @Restricted(NoExternalUse.class)
-        @Nonnull
+        @NonNull
         public static DescriptorImpl getOrDie() {
             return (CVSSCM.DescriptorImpl) Jenkins.get().getDescriptorOrDie(CVSSCM.class);
         }

--- a/src/main/java/hudson/scm/CvsProjectset.java
+++ b/src/main/java/hudson/scm/CvsProjectset.java
@@ -45,8 +45,8 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 
 public class CvsProjectset extends AbstractCvs {
@@ -127,8 +127,8 @@ public class CvsProjectset extends AbstractCvs {
 
 
     @Override
-    public void checkout(final @Nonnull Run<?,?> build, final @Nonnull Launcher launcher, final @Nonnull FilePath workspace,
-    		             final @Nonnull TaskListener listener, final @CheckForNull File changelogFile,
+    public void checkout(final @NonNull Run<?,?> build, final @NonNull Launcher launcher, final @NonNull FilePath workspace,
+                         final @NonNull TaskListener listener, final @CheckForNull File changelogFile,
     		             final @CheckForNull SCMRevisionState baseline) throws IOException, InterruptedException {
         if (!isCanUseUpdate()) {
             workspace.deleteContents();

--- a/src/spotbugs/excludesFilter.xml
+++ b/src/spotbugs/excludesFilter.xml
@@ -200,4 +200,13 @@
       <Field name="UPDATE_REPEATS"/>
     </Or>
   </Match>
+  <Match>
+    <Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"/>
+    <Class name="hudson.scm.CVSChangeLogSet$File"/>
+    <Or>
+      <Field name="name"/>
+      <Field name="parent"/>
+      <Field name="revision"/>
+    </Or>
+  </Match>
 </FindBugsFilter>


### PR DESCRIPTION
## Replace JSR-305 annotations with spotbugs annotations

Annotations for Nonnull, CheckForNull, and several others were proposed for Java as part of dormant Java specification request JSR-305. The proposal never became a part of standard Java.

Jenkins plugins should switch from using JSR-305 annotations to use Spotbugs annotations that provide the same semantics.

The [mailing list discussion](https://groups.google.com/g/jenkinsci-dev/c/uE1wwtVi1W0/m/gLxdEJmlBQAJ) from James Nord describes the affected annotations and why they should be replaced with annotations that are actively maintained.

The ["Improve a plugin" tutorial](https://www.jenkins.io/doc/developer/tutorial-improve/replace-jsr-305-annotations/) provides instructions to perform this change.

An [OpenRewrite recipe](https://docs.openrewrite.org/recipes/jenkins/javaxannotationstospotbugs) is also available and is even better than the tutorial.

Also resolves the 3 spotbugs warnings that are visible on the master branch.

### Testing done

Confirmed that automated tests pass on Linux with Java 21.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
