### PR TITLE
Explicitly declare dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,8 @@
     <jenkins.baseline>2.479</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
+    <hpi.bundledArtifacts>cglib,commons-digester3,cvsclient,jsch</hpi.bundledArtifacts>
+    <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
@@ -67,6 +69,11 @@
     </dependencyManagement>
   
   <dependencies>
+    <dependency>
+      <groupId>commons-beanutils</groupId>
+      <artifactId>commons-beanutils</artifactId>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-digester3</artifactId>


### PR DESCRIPTION
## Explicitly declare dependencies

Reduce the risk that new dependencies will be injected accidentally from a dependency update.

Rely on the commons-beanutils that is provided by Jenkins rather than including a copy in the hpi file of the plugin.

The [developer documentation](https://www.jenkins.io/doc/developer/plugin-development/dependencies-and-class-loading/#build-time-validation-of-bundled-artifacts) provides more details.

Originally added to Maven hpi plugin in pull request:

* https://github.com/jenkinsci/maven-hpi-plugin/pull/771

### Testing done

* Confirmed that automated tests pass

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
